### PR TITLE
fix: replace bare except: with except Exception

### DIFF
--- a/ScrapeAllProxies.py
+++ b/ScrapeAllProxies.py
@@ -266,7 +266,8 @@ def run_scraper_pipeline(
                     netloc = urlparse(conv_url).netloc.replace("www.", "")
                     if conv_url not in existing_urls and netloc not in existing_domains:
                         filtered_urls.append(d_url)
-                except: pass
+                except Exception:
+                    pass  # Skip URLs that fail to parse
             discovered_urls = filtered_urls
 
         if not discovered_urls: return []


### PR DESCRIPTION
## Summary
Fixed bare `except:` clauses that catch all exceptions including SystemExit and KeyboardInterrupt.

## Changes
- `ScrapeAllProxies.py`: Changed `except: pass` to `except Exception: pass` with explanatory comment

## Why this matters
Bare `except:` can hide bugs by catching unexpected exceptions like SystemExit, making debugging harder and potentially leaving the program in an inconsistent state.

— Sent via @AmSach bot